### PR TITLE
Popup UX and TST Improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,48 @@
 - Keyboard shortcut for quick access to the search dialog.
     - Customizable keyboard shortcut via about:addons → gear → Manage Extension Shortcuts.
 - Option to disable the initial tab hiding action (once the privacy dialog is accepted).
-    - The addon hides and shows the last tab on startup to trigger Firefox’s permission prompt without interfering with the search dialog. Once permission is granted, you can disable this behavior. See the limitations section for more information and links.
+    - The addon briefly hides and shows the last tab on startup to trigger Firefox's tab-hiding permission prompt. Once permission is granted, you can disable this startup initialization step.
 - Never hides pinned or active tabs.
 - Tab hiding is temporary: all tabs are restored when the search is cleared or the popup is closed.
+- Changing search-affecting options during an active search clears the current search and restores tabs to their pre-search state.
+    - Search-affecting options are: Search URLs, Search tab titles, Search contents of loaded tabs, Real-time search, Support for Tree Style Tab (TST), and Auto-expand trees with matched tabs.
+    - "Select all matching tabs on close" and "Disable initial hide action" do not interrupt an in-progress search.
 - Keyboard shortcut to open the search dialog.
 - Shows the number of remaining tabs to be hidden/shown on the addon icon
 - Option to multi-select matching tabs after search is complete
+    - "Select all matching tabs on close" only applies when the search session ends.
+- TST search results are visually flattened during a search for faster scanning.
+    - Matching tabs are left-aligned and rendered with symmetric horizontal spacing while the search is active.
+    - The original tree structure is restored after the search ends.
+- TST can auto-expand parent trees for matched tabs when using the close-time multi-select flow.
+    - The "Auto-expand trees with matched tabs" option is shown only when TST support is enabled.
+
+
+## Search Dialog Behavior
+
+- Opening the popup starts a search session scoped to the current state of visible/hidden tabs.
+- While searching, changing some options will clear the search input and restore tabs to their pre-search state so results stay consistent.
+
+### Options That Reset an Active Search
+
+- Search URLs
+- Search tab titles
+- Search contents of loaded tabs
+- Real-time search
+- Support for Tree Style Tab (TST)
+- Auto-expand trees with matched tabs
+
+### Options That Do Not Reset an Active Search
+
+- Select all matching tabs on close
+- Disable initial hide action
+
+### Notes
+
+- "Select all matching tabs on close" applies when the search session ends; it does not change in-progress filtering.
+- "Disable initial hide action" only affects the startup permission initialization step; it does not change matching/filtering during a search.
+- "Auto-expand trees with matched tabs" is only shown when TST support is enabled.
+- Clicking either blue info button cancels any active search, restores tab visibility/state, opens the help page in a new active tab, and closes the popup.
 
 
 ## Limitations
@@ -59,65 +95,105 @@
 
 ## Changelog
 
-<details id="History"><summary>History</summary>
+<details open>
+<summary><strong>v0.6.0 - Popup UX and TST Improvements</strong></summary>
 
-### v0.5.5
+- Clarified option reset behavior in the popup.
+    - Search-affecting options clear the active search and restore tabs to their pre-search state.
+    - Both TST options ("Support for Tree Style Tab" and "Auto-expand trees with matched tabs") now reset an active search to ensure TST state is fully restored.
+    - "Select all matching tabs on close" and "Disable initial hide action" do not reset an active search.
+- Updated the TST search presentation.
+    - Flattened search results now keep a consistent left and right gutter while searching.
+    - Added defensive TST CSS so custom tab margins are less likely to break the flattened search layout.
+- Updated the popup relationship between TST options.
+    - The "Auto-expand trees with matched tabs" option is now progressively disclosed and only shown when TST support is enabled.
+- Updated info-button behavior in the popup.
+    - Opening privacy/content help now first resets any active search, then opens the help page in an active tab and closes the popup.
+</details>
+
+<details>
+<summary><strong>v0.5.5 - Manual Selection and Collapsed Tree Fixes</strong></summary>
+
 - Fixed https://github.com/irvinm/TabSearch/issues/11.
     - (General) Fixed issue where manually selecting a tab from a search would not make that tab the active tab.
     - (TST) Fixed issue where manually selecting a tab that was in a collapsed tree would be selected, but when the tree was restored (collapsed), the parent ends up becoming the active tab.
-      
-### v0.5.2
-- Updated logic for tracking TST parents and tree states
-- Updated the logging to ensure "[TabSearch]" is included for all statements
+</details>
 
-### v0.5.1
-- Performance improvements via reduced actions for TST
-    - (TST) Ensure register with TST only once per session
-    - (TST) Only "expand all trees" once per search per window
-    - (TST) Only apply "flatted" style once per search
-    - (TST) Refactor tree restoration process to only call parents, not every tab
+<details>
+<summary><strong>v0.5.2 - Tree Tracking and Logging Cleanup</strong></summary>
 
-### v0.5.0
-- Added initial support for Tree Style Tab (TST)
-    - Interacts directly with TST to apply a flattening style to matched tabs while searching and to remove any twistys
-    - Expands all trees during the search to ensure visibility
-    - Restores the original state of tress (expanded/collapsed) after the search is complete
-- If options of the search are changed mid-search, the search is cleared and restarted
-    - Want consistent results and not have to worry if changing an option mid-search is logical or not
-- Disabled being able to use "tab" to switch between UI elements
-    - There is a Firefox limitation that popup.html can be destroyed too fast to generate an "unload" event to be processed
-    - Monitoring for "focusout" works well, but also included keyboard transitions to other UI elements
-- Added new option for TST to "auto-expand" trees if the option to "Select all matching tabs on close" is also enabled
-    - This would ensure you can visually find all the highlighted tabs even if they were buried in collapsed trees
+- Updated logic for tracking TST parents and tree states.
+- Updated the logging to ensure "[TabSearch]" is included for all statements.
+</details>
 
-### v0.4.1
-  - Fixed [Select all matching tabs on close - Multiple windows not working](https://github.com/irvinm/TabSearch/issues/2)
-    - Selecting matching tabs across multiple windows should now work
-    - There is a Firefox limitation that dragging tabs has to be done PER window
+<details>
+<summary><strong>v0.5.1 - TST Performance Optimizations</strong></summary>
 
-### v0.4.0
-- Added new option to multi-select matching tabs
+- Performance improvements via reduced actions for TST.
+    - (TST) Ensure register with TST only once per session.
+    - (TST) Only "expand all trees" once per search per window.
+    - (TST) Only apply "flattened" style once per search.
+    - (TST) Refactor tree restoration process to only call parents, not every tab.
+</details>
 
-### v0.3.0
-- Added support to show the number of tabs still to be processed (hidden or shown) to the addon icon counter
-- Reduced the amount of white-space near the borders of the search popup
-- Disabled the search button when "real-time searches" are enabled
-- Cleaned up some logic around options to avoid searches from being cleared mid-search
+<details>
+<summary><strong>v0.5.0 - Initial Tree Style Tab Support</strong></summary>
 
-### v0.2.0
+- Added initial support for Tree Style Tab (TST).
+    - Interacts directly with TST to apply a flattening style to matched tabs while searching and to remove any twistys.
+    - Expands all trees during the search to ensure visibility.
+    - Restores the original state of trees (expanded/collapsed) after the search is complete.
+- If search-affecting options are changed mid-search, the search is cleared and restarted.
+    - This keeps behavior consistent when search options are changed during an active session.
+- Disabled being able to use "tab" to switch between UI elements.
+    - There is a Firefox limitation that popup.html can be destroyed too fast to generate an "unload" event to be processed.
+    - Monitoring for "focusout" works well, but also included keyboard transitions to other UI elements.
+- Added new option for TST to "auto-expand" trees if the option to "Select all matching tabs on close" is also enabled.
+    - This ensures you can visually find all highlighted tabs even if they were buried in collapsed trees.
+</details>
+
+<details>
+<summary><strong>v0.4.1 - Multi-Window Close-Time Selection Fix</strong></summary>
+
+- Fixed [Select all matching tabs on close - Multiple windows not working](https://github.com/irvinm/TabSearch/issues/2).
+    - Selecting matching tabs across multiple windows should now work.
+    - There is a Firefox limitation that dragging tabs has to be done per window.
+</details>
+
+<details>
+<summary><strong>v0.4.0 - Close-Time Multi-Select Option</strong></summary>
+
+- Added new option to multi-select matching tabs.
+</details>
+
+<details>
+<summary><strong>v0.3.0 - Search Counter and Popup UX Improvements</strong></summary>
+
+- Added support to show the number of tabs still to be processed (hidden or shown) in the addon icon counter.
+- Reduced the amount of whitespace near the borders of the search popup.
+- Disabled the search button when "real-time searches" are enabled.
+- Cleaned up some logic around options to avoid searches from being cleared mid-search.
+</details>
+
+<details>
+<summary><strong>v0.2.0 - Audio Tab Search Experience</strong></summary>
+
 - Updated styling for the search dialog.
-- Added support for searching tabs playing audio:
+- Added support for searching tabs playing audio.
     - 0 matches: Shows a custom dialog indicating no tabs were found.
     - 1 match: Switches directly to that tab.
     - 2+ matches: Hides all non-audio tabs.
+</details>
 
-### v0.1.0
+<details>
+<summary><strong>v0.1.0 - Initial Release</strong></summary>
+
 - Initial release support for:
-    - Searching tab URL
-    - Searching tab title
-    - Searching tab content (text inside loaded tabs)
-    - Option to initially hide a tab in order to get Firefox to ask for explicit permission
-    - Option for real-time search (filter as you type) or manual search (on submit)
-    - Keyboard short-cut support to bring up search dialog
-    - Support to change key assignment via standard about:addons → gear → Manage Extension Shortcuts
+    - Searching tab URL.
+    - Searching tab title.
+    - Searching tab content (text inside loaded tabs).
+    - Option to initially hide a tab in order to get Firefox to ask for explicit permission.
+    - Option for real-time search (filter as you type) or manual search (on submit).
+    - Keyboard shortcut support to bring up search dialog.
+    - Support to change key assignment via standard about:addons -> gear -> Manage Extension Shortcuts.
 </details>

--- a/background.js
+++ b/background.js
@@ -244,7 +244,6 @@ async function restoreTabsToInitialState(recentActivationToPreserve = null) {
         children[windowId] = [];
         collapsedParents[windowId] = [];
         treesExpandedThisSearch[windowId] = {};
-        originalTSTTreeStructureByWindow[windowId] = treeStructure;
       }
     } catch (e) {
       console.warn('[TabSearch][TST] Failed to restore tree collapsed/expanded state:', e);
@@ -261,6 +260,7 @@ function resetSearchTrackingState() {
   treesExpandedThisSearch = {};
   originalTSTTreeStructureByWindow = {};
   originalTSTTreeSnapshotTaken = false;
+  flattenedStateAppliedThisSearch = false;
   recentTabActivation = null;
 }
 

--- a/background.js
+++ b/background.js
@@ -24,11 +24,19 @@ const TST_REGISTER_MESSAGE = {
   // See: https://github.com/piroor/treestyletab/wiki/API-for-other-addons#register-self
   // Remove all indentation and hide the twisty icon in flattened state
   style: `
+    .tab.flattened:not(.pinned) {
+      margin-left: 0 !important;
+      margin-right: 0 !important;
+    }
     .tab.flattened:not(.pinned) tab-twisty::before {
       display: none !important;
     }
     .tab.flattened:not(.pinned) tab-item-substance {
       margin-left: var(--shift-tabs-for-scrollbar-distance) !important;
+      margin-right: var(--shift-tabs-for-scrollbar-distance) !important;
+      width: calc(100% - var(--shift-tabs-for-scrollbar-distance) - var(--shift-tabs-for-scrollbar-distance)) !important;
+      max-width: calc(100% - var(--shift-tabs-for-scrollbar-distance) - var(--shift-tabs-for-scrollbar-distance)) !important;
+      box-sizing: border-box !important;
     }
   `,
 }
@@ -132,6 +140,130 @@ function startProgressIndicator(getCountFn) {
   }, 500); // Update 2 times a second
 }
 
+async function restoreTabsToInitialState(recentActivationToPreserve = null) {
+  const allTabs = await browser.tabs.query({});
+
+  // Use flattenedStateAppliedThisSearch rather than the current tstSupport storage
+  // value, because the option may already have been toggled off before this runs.
+  if (flattenedStateAppliedThisSearch) {
+    const allTabIds = allTabs.map(tab => tab.id);
+    removeFlattenedState(allTabIds);
+  }
+
+  try {
+    const hiddenTabIds = allTabs.filter(tab => tab.hidden).map(tab => tab.id);
+    if (hiddenTabIds.length > 0) {
+      updateBadge(hiddenTabIds.length);
+      startProgressIndicator(async () => {
+        const tabsNow = await browser.tabs.query({});
+        return tabsNow.filter(tab => tab.hidden).length;
+      });
+      console.log(`[TabSearch] Showing ${hiddenTabIds.length} hidden tabs:`, hiddenTabIds);
+      await browser.tabs.show(hiddenTabIds);
+    } else {
+      updateBadge(0);
+      if (progressInterval) {
+        clearInterval(progressInterval);
+        progressInterval = null;
+      }
+    }
+  } catch (e) {
+    updateBadge(0);
+    if (progressInterval) {
+      clearInterval(progressInterval);
+      progressInterval = null;
+    }
+  }
+
+  if (originalTSTTreeSnapshotTaken && originalTSTTreeStructureByWindow) {
+    try {
+      const activeTabsByWindow = {};
+      const allWindows = await browser.windows.getAll({ populate: false });
+      for (const window of allWindows) {
+        const tabsInWindow = await browser.tabs.query({ windowId: window.id, active: true });
+        if (tabsInWindow.length > 0) {
+          activeTabsByWindow[window.id] = tabsInWindow[0].id;
+        }
+      }
+
+      for (const [windowId, treeStructure] of Object.entries(originalTSTTreeStructureByWindow)) {
+        let tabIdToPreserve;
+
+        if (recentActivationToPreserve && recentActivationToPreserve.windowId === Number(windowId)) {
+          tabIdToPreserve = recentActivationToPreserve.tabId;
+          console.log(`[TabSearch][TST] Window ${windowId}: Will preserve manually selected tab ${tabIdToPreserve}`);
+        } else {
+          tabIdToPreserve = activeTabsByWindow[windowId];
+          if (tabIdToPreserve) {
+            console.log(`[TabSearch][TST] Window ${windowId}: Will preserve currently active tab ${tabIdToPreserve}`);
+          }
+        }
+
+        let parentsToKeepExpanded = new Set();
+
+        if (tabIdToPreserve && collapsedParents[windowId] && collapsedParents[windowId].length > 0) {
+          try {
+            const currentTree = await browser.runtime.sendMessage(TST_ID, {
+              type: 'get-light-tree',
+              tabs: '*',
+              window: Number(windowId)
+            });
+
+            if (currentTree && Array.isArray(currentTree)) {
+              const tabIdToNode = {};
+              currentTree.forEach(node => { tabIdToNode[node.id] = node; });
+              const tabNode = tabIdToNode[tabIdToPreserve];
+
+              if (tabNode && tabNode.ancestorTabIds && tabNode.ancestorTabIds.length > 0) {
+                const collapsedParentIds = collapsedParents[windowId].map(parent => parent.id);
+
+                for (const ancestorId of tabNode.ancestorTabIds) {
+                  if (collapsedParentIds.includes(ancestorId)) {
+                    parentsToKeepExpanded.add(ancestorId);
+                  }
+                }
+              }
+            }
+          } catch (e) {
+            console.warn('[TabSearch][TST] Failed to get current tree structure for tab visibility check:', e);
+          }
+        }
+
+        const parentsToCollapse = collapsedParents[windowId].filter(parent => !parentsToKeepExpanded.has(parent.id));
+
+        if (parentsToCollapse.length > 0) {
+          await browser.runtime.sendMessage(TST_ID, {
+            type: 'collapse-tree',
+            window: Number(windowId),
+            tabs: parentsToCollapse,
+            recursively: false
+          });
+        }
+
+        parents[windowId] = [];
+        children[windowId] = [];
+        collapsedParents[windowId] = [];
+        treesExpandedThisSearch[windowId] = {};
+        originalTSTTreeStructureByWindow[windowId] = treeStructure;
+      }
+    } catch (e) {
+      console.warn('[TabSearch][TST] Failed to restore tree collapsed/expanded state:', e);
+    }
+  }
+}
+
+function resetSearchTrackingState() {
+  lastHiddenTabIds = [];
+  searchInProgress = false;
+  parents = {};
+  children = {};
+  collapsedParents = {};
+  treesExpandedThisSearch = {};
+  originalTSTTreeStructureByWindow = {};
+  originalTSTTreeSnapshotTaken = false;
+  recentTabActivation = null;
+}
+
 browser.runtime.onMessage.addListener(async (msg, sender) => {
 
   // Check if TST support is enabled
@@ -141,6 +273,13 @@ browser.runtime.onMessage.addListener(async (msg, sender) => {
 
   if (msg.action === 'clear-matched-tabs') {
     lastMatchedTabIds = [];
+    return;
+  }
+
+  if (msg.action === 'reset-search-state') {
+    await restoreTabsToInitialState();
+    lastMatchedTabIds = [];
+    resetSearchTrackingState();
     return;
   }
 
@@ -359,145 +498,7 @@ browser.runtime.onMessage.addListener(async (msg, sender) => {
       console.log('[TabSearch] No recent tab activation, user likely clicked away');
     }
     
-    const allTabs = await browser.tabs.query({});
-
-    // If TST support is enabled, remove flattened state from all tabs in one call
-    if (tstEnabled) {
-      const allTabIds = allTabs.map(tab => tab.id);
-      removeFlattenedState(allTabIds);
-    }
-
-    // Always try to show all hidden tabs, even if lastHiddenTabIds is empty
-    try {
-      const hiddenTabIds = allTabs.filter(tab => tab.hidden).map(tab => tab.id);
-      if (hiddenTabIds.length > 0) {
-        // Start progress indicator for unhiding
-        updateBadge(hiddenTabIds.length);
-        startProgressIndicator(async () => {
-          const tabsNow = await browser.tabs.query({});
-          return tabsNow.filter(tab => tab.hidden).length;
-        });
-        console.log(`[TabSearch] Showing ${hiddenTabIds.length} hidden tabs:`, hiddenTabIds);
-        await browser.tabs.show(hiddenTabIds);
-      } else {
-        updateBadge(0);
-        if (progressInterval) {
-          clearInterval(progressInterval);
-          progressInterval = null;
-        }
-      }
-    } catch (e) {
-      updateBadge(0);
-      if (progressInterval) {
-        clearInterval(progressInterval);
-        progressInterval = null;
-      }
-    }    // Now restore the collapsed/expanded state of trees
-    if (tstEnabled && originalTSTTreeSnapshotTaken && originalTSTTreeStructureByWindow) {
-      try {
-        // Determine which tab should be kept visible
-        let tabToKeepVisible = null;
-        
-        if (wasRecentActivation) {
-          // User clicked on a specific tab - keep that tab visible
-          tabToKeepVisible = recentTabActivation.tabId;
-          console.log(`[TabSearch][TST] Will preserve visibility for manually selected tab: ${tabToKeepVisible}`);
-        } else {
-          // User clicked away - use currently active tab in each window (existing behavior)
-          console.log('[TabSearch][TST] Will preserve visibility for currently active tabs');
-        }
-
-        // First, identify which tab is currently active in each window (for click-away scenario)
-        const activeTabsByWindow = {};
-        const allWindows = await browser.windows.getAll({ populate: false });
-        for (const window of allWindows) {
-          const tabsInWindow = await browser.tabs.query({ windowId: window.id, active: true });
-          if (tabsInWindow.length > 0) {
-            activeTabsByWindow[window.id] = tabsInWindow[0].id;
-          }
-        }        for (const [windowId, treeStructure] of Object.entries(originalTSTTreeStructureByWindow)) {
-          // Determine which tab to preserve visibility for in this window
-          let tabIdToPreserve;
-          
-          if (wasRecentActivation && recentTabActivation.windowId === Number(windowId)) {
-            // This is the window where the user manually selected a tab
-            tabIdToPreserve = recentTabActivation.tabId;
-            console.log(`[TabSearch][TST] Window ${windowId}: Will preserve manually selected tab ${tabIdToPreserve}`);
-          } else {
-            // For other windows, preserve the currently active tab
-            tabIdToPreserve = activeTabsByWindow[windowId];
-            if (tabIdToPreserve) {
-              console.log(`[TabSearch][TST] Window ${windowId}: Will preserve currently active tab ${tabIdToPreserve}`);
-            }
-          }
-          
-          let parentsToKeepExpanded = new Set();
-          
-          // If there's a tab to preserve in this window, check if it would be hidden by collapsing trees
-          if (tabIdToPreserve && collapsedParents[windowId] && collapsedParents[windowId].length > 0) {
-            // Get current tree structure to find the tab's ancestors
-            try {
-              const currentTree = await browser.runtime.sendMessage(TST_ID, {
-                type: 'get-light-tree',
-                tabs: '*',
-                window: Number(windowId)
-              });
-                if (currentTree && Array.isArray(currentTree)) {
-                const tabIdToNode = {};
-                currentTree.forEach(node => { tabIdToNode[node.id] = node; });
-                const tabNode = tabIdToNode[tabIdToPreserve];
-                
-                console.log(`[TabSearch][TST] Window ${windowId}: Looking for tab ${tabIdToPreserve} in tree`);
-                console.log(`[TabSearch][TST] Window ${windowId}: Tab node found:`, tabNode ? `Yes (ancestors: ${tabNode.ancestorTabIds})` : 'No');
-                
-                if (tabNode && tabNode.ancestorTabIds && tabNode.ancestorTabIds.length > 0) {
-                  // Check if any of the tab's ancestors are in the list of parents to collapse
-                  const collapsedParentIds = collapsedParents[windowId].map(parent => parent.id);
-                  console.log(`[TabSearch][TST] Window ${windowId}: Originally collapsed parent IDs:`, collapsedParentIds);
-                  console.log(`[TabSearch][TST] Window ${windowId}: Tab ${tabIdToPreserve} ancestor IDs:`, tabNode.ancestorTabIds);
-                  
-                  for (const ancestorId of tabNode.ancestorTabIds) {
-                    if (collapsedParentIds.includes(ancestorId)) {
-                      parentsToKeepExpanded.add(ancestorId);
-                      console.log(`[TabSearch][TST] Window ${windowId}: Keeping parent ${ancestorId} expanded to preserve visibility of tab ${tabIdToPreserve}`);
-                    }
-                  }
-                } else {
-                  console.log(`[TabSearch][TST] Window ${windowId}: Tab ${tabIdToPreserve} has no ancestors or is not in a tree`);
-                }
-              }
-            } catch (e) {
-              console.warn('[TabSearch][TST] Failed to get current tree structure for tab visibility check:', e);
-            }
-          }
-            // Filter out parents that should be kept expanded to preserve tab visibility
-          const parentsToCollapse = collapsedParents[windowId].filter(parent => !parentsToKeepExpanded.has(parent.id));
-          
-          if (parentsToCollapse.length > 0) {
-            console.log(`[TabSearch][TST] Window ${windowId}: Collapsing ${parentsToCollapse.length} trees (keeping ${parentsToKeepExpanded.size} expanded for tab ${tabIdToPreserve})`);
-            console.log(`[TabSearch][TST] Window ${windowId}: Parents to collapse:`, parentsToCollapse.map(p => p.id));
-            console.log(`[TabSearch][TST] Window ${windowId}: Parents to keep expanded:`, Array.from(parentsToKeepExpanded));
-            await browser.runtime.sendMessage(TST_ID, {
-              type: 'collapse-tree',
-              window: Number(windowId),
-              tabs: parentsToCollapse,
-              recursively: false
-            });
-          } else {
-            console.log(`[TabSearch][TST] Window ${windowId}: No trees to collapse (all ${collapsedParents[windowId].length} kept expanded for tab ${tabIdToPreserve})`);
-          }
-          
-          // Clear the tracking arrays for this window
-          parents[windowId] = [];
-          children[windowId] = [];
-          collapsedParents[windowId] = [];
-          treesExpandedThisSearch[windowId] = {};
-          originalTSTTreeStructureByWindow[windowId] = treeStructure;
-        }
-      } catch (e) {
-        console.warn('[TabSearch][TST] Failed to restore tree collapsed/expanded state:', e);
-      }
-    }
+    await restoreTabsToInitialState(wasRecentActivation ? recentTabActivation : null);
 
     // Select all matching tabs if option is enabled
     const items = await browser.storage.local.get(["selectMatchingTabs", "tstSupport", "tstAutoExpand"]);
@@ -574,15 +575,7 @@ browser.runtime.onMessage.addListener(async (msg, sender) => {
       // After handling, clear lastMatchedTabIds so it doesn't persist for next popup
       lastMatchedTabIds = [];
     }    // Reset all stateful objects to avoid stale data
-    lastHiddenTabIds = [];
-    searchInProgress = false;
-    parents = {};
-    children = {};
-    collapsedParents = {};
-    treesExpandedThisSearch = {};
-    originalTSTTreeStructureByWindow = {};
-    originalTSTTreeSnapshotTaken = false;
-    recentTabActivation = null;  // Clear the recent activation tracking
+    resetSearchTrackingState();
   }
 });
 

--- a/common.css
+++ b/common.css
@@ -1,7 +1,3 @@
-/* TST sub-option indentation for popup.html */
-.tst-suboption {
-  margin-left: 2em;
-}
 .icon-btn#audio-search-btn {
   margin-left: 8px;
   width: 40px;
@@ -20,7 +16,26 @@
 }
 /* Ensure one search type option per row */
 .option-list {
-  margin-bottom: 4px;
+  margin: 0;
+}
+
+.option-list + .option-list {
+  margin-top: 4px;
+}
+.tst-suboption {
+  margin-left: 28px;
+}
+.tst-suboption-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  line-height: 1.2;
+}
+.tst-suboption-label input {
+  margin: 0;
+}
+.tst-suboption[hidden] {
+  display: none;
 }
 /* Modernized popup styles */
 .search-bar {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Tab Search",
-  "version": "0.5.5",
+  "version": "0.6.0",
   "description": "Search tabs and hide non-matching ones.",
   "permissions": ["tabs", "tabHide", "storage", "find"],
   "host_permissions": ["<all_urls>"],

--- a/popup.html
+++ b/popup.html
@@ -54,9 +54,9 @@
       </div>
       <div class="option-list">
         <label><input type="checkbox" id="tst-support"> Support for Tree Style Tab (TST)</label>
-        <div class="option-list tst-suboption">
-          <label><input type="checkbox" id="tst-auto-expand"> Auto-expand trees with matched tabs</label>
-        </div>
+      </div>
+      <div class="option-list tst-suboption" id="tst-auto-expand-row" hidden>
+        <label class="tst-suboption-label"><input type="checkbox" id="tst-auto-expand"> <span>Auto-expand trees with matched tabs</span></label>
       </div>
     </fieldset>
   </form>

--- a/popup.js
+++ b/popup.js
@@ -16,9 +16,9 @@ function handleOptionChange() {
       });
     });
   }
-  // Tell background to clear lastMatchedTabIds so no tabs are re-highlighted
+  // Tell background to restore the pre-search tab state
   if (browser && browser.runtime && browser.runtime.sendMessage) {
-    browser.runtime.sendMessage({ action: 'clear-matched-tabs' });
+    browser.runtime.sendMessage({ action: 'reset-search-state' });
   }
 }
 
@@ -114,6 +114,18 @@ document.addEventListener('DOMContentLoaded', function() {
 // Log when popup.html is opened
 console.warn('[TabSearch] popup.html opened at', new Date().toISOString());
 
+let popupCloseMessageSent = false;
+
+function notifyPopupClosed() {
+  if (popupCloseMessageSent) {
+    return;
+  }
+
+  popupCloseMessageSent = true;
+  console.log('[TabSearch] focusout: Sending popup-closed message to background');
+  browser.runtime.sendMessage({ action: 'popup-closed' });
+}
+
 // Log document.activeElement on every focus change
 document.addEventListener('focusin', (e) => {
   console.log('[TabSearch] focusin: document.activeElement:', document.activeElement, document.activeElement && document.activeElement.id);
@@ -121,27 +133,55 @@ document.addEventListener('focusin', (e) => {
 
 document.addEventListener('focusout', (e) => {
   console.log('[TabSearch] focusout: document.activeElement:', document.activeElement, document.activeElement && document.activeElement.id);
-  
-  console.log('[TabSearch] focusout: Sending popup-closed message to background');
-  browser.runtime.sendMessage({ action: 'popup-closed' });
+
+  const nextFocusedElement = e.relatedTarget;
+  if (nextFocusedElement && document.contains(nextFocusedElement)) {
+    return;
+  }
+
+  setTimeout(() => {
+    if (!document.hasFocus()) {
+      notifyPopupClosed();
+    }
+  }, 0);
 });
 
 // Handle privacy info button click (must be in external JS due to CSP)
 document.addEventListener('DOMContentLoaded', function() {
+  async function openInfoTab(pageName) {
+    // Keep info pages out of an in-progress filtered state without re-highlighting tabs.
+    const searchInput = document.getElementById('search');
+    if (searchInput) {
+      searchInput.value = '';
+    }
+
+    if (browser && browser.runtime && browser.runtime.sendMessage) {
+      try {
+        await browser.runtime.sendMessage({ action: 'reset-search-state' });
+      } catch (err) {
+        console.warn('[TabSearch] Failed to reset search state before opening info tab:', err);
+      }
+    }
+
+    if (browser && browser.tabs && browser.tabs.create && browser.runtime && browser.runtime.getURL) {
+      const url = browser.runtime.getURL(pageName);
+      await browser.tabs.create({ url: url, active: true });
+      window.close();
+    }
+  }
+
   var btn = document.getElementById('privacy-info-btn');
   if (btn) {
-    btn.addEventListener('click', function(e) {
+    btn.addEventListener('click', async function(e) {
       e.preventDefault();
-      var url = browser.runtime.getURL('privacy.html');
-      window.open(url, '_blank');
+      await openInfoTab('privacy.html');
     });
   }
   var contentsBtn = document.getElementById('search-contents-info-btn');
   if (contentsBtn) {
-    contentsBtn.addEventListener('click', function(e) {
+    contentsBtn.addEventListener('click', async function(e) {
       e.preventDefault();
-      var url = browser.runtime.getURL('search-contents.html');
-      window.open(url, '_blank');
+      await openInfoTab('search-contents.html');
     });
   }
 });
@@ -193,12 +233,12 @@ document.getElementById('search').addEventListener('keydown', function(e) {
     // Send popup-closed message to background before popup closes
     if (browser && browser.windows && browser.runtime && browser.runtime.sendMessage) {
       browser.windows.getCurrent().then(win => {
-        browser.runtime.sendMessage({ action: 'popup-closed', windowId: win.id });
+        notifyPopupClosed();
       }).catch(err => {
-        browser.runtime.sendMessage({ action: 'popup-closed' });
+        notifyPopupClosed();
       });
     } else {
-      browser.runtime.sendMessage({ action: 'popup-closed' });
+      notifyPopupClosed();
     }
     // Let the popup close naturally
   }
@@ -247,7 +287,16 @@ window.addEventListener('DOMContentLoaded', function() {
     document.getElementById('disable-empty-tab').checked = disableEmptyTabChecked;
     document.getElementById('tst-support').checked = tstSupportChecked;
     document.getElementById('tst-auto-expand').checked = tstAutoExpandChecked;
-    document.getElementById('tst-auto-expand').disabled = !tstSupportChecked;
+
+    const tstAutoExpandRow = document.getElementById('tst-auto-expand-row');
+    const tstAutoExpandInput = document.getElementById('tst-auto-expand');
+
+    function updateTSTSuboptionVisibility(enabled) {
+      tstAutoExpandRow.hidden = !enabled;
+      tstAutoExpandInput.disabled = !enabled;
+    }
+
+    updateTSTSuboptionVisibility(tstSupportChecked);
 
     // If all were undefined, save the defaults so future loads are correct
     if (allUndefined) {
@@ -256,11 +305,7 @@ window.addEventListener('DOMContentLoaded', function() {
     document.getElementById('tst-support').addEventListener('change', function() {
       const checked = this.checked;
       browser.storage.local.set({ tstSupport: checked });
-      document.getElementById('tst-auto-expand').disabled = !checked;
-      if (!checked) {
-        document.getElementById('tst-auto-expand').checked = false;
-        browser.storage.local.set({ tstAutoExpand: false });
-      }
+      updateTSTSuboptionVisibility(checked);
       if (checked && window.TabSearchTST && window.TabSearchTST.registerWithTST) {
         window.TabSearchTST.registerWithTST();
       }
@@ -269,6 +314,7 @@ window.addEventListener('DOMContentLoaded', function() {
     document.getElementById('tst-auto-expand').addEventListener('change', function() {
       const checked = this.checked;
       browser.storage.local.set({ tstAutoExpand: checked });
+      handleOptionChange();
     });
 
   updateSearchButtonState();
@@ -360,7 +406,6 @@ window.addEventListener('DOMContentLoaded', function() {
   // Attach event listeners for all options
   document.getElementById('select-matching-tabs').addEventListener('change', function() {
     saveAllOptions();
-    handleOptionChange();
   });
   document.getElementById('search-urls').addEventListener('change', function(e) {
     const prev = document.activeElement;
@@ -390,7 +435,6 @@ window.addEventListener('DOMContentLoaded', function() {
   });
   document.getElementById('disable-empty-tab').addEventListener('change', function() {
     saveAllOptions();
-    handleOptionChange();
   });
 });
 

--- a/popup.js
+++ b/popup.js
@@ -231,15 +231,7 @@ document.getElementById('search').addEventListener('keydown', function(e) {
     doSearch();
   } else if (e.key === 'Escape' || e.key === 'Esc') {
     // Send popup-closed message to background before popup closes
-    if (browser && browser.windows && browser.runtime && browser.runtime.sendMessage) {
-      browser.windows.getCurrent().then(win => {
-        notifyPopupClosed();
-      }).catch(err => {
-        notifyPopupClosed();
-      });
-    } else {
-      notifyPopupClosed();
-    }
+    notifyPopupClosed();
     // Let the popup close naturally
   }
 });

--- a/privacy.html
+++ b/privacy.html
@@ -29,14 +29,15 @@
 
     <p>
       <b>Note #1:</b> If you do not accept the permission, the dialog can appear each time the extension tries to hide a tab and may cause UI conflicts between the search dialog and Firefox's privacy dialog.
-    </p>
-    <p>
-      Once you allow it, you can select <b>"Disable initial hide action"</b> in extension settings to skip this startup initialization step in the future.
+      This is a known Firefox behavior being tracked in the following references:
     </p>
     <ul class="section-list">
       <li>Reference: <a href="https://discourse.mozilla.org/t/initial-tabs-hide-warning-dialog/142979" target="_blank" rel="noopener noreferrer">My discussion on Mozilla's Discourse site</a></li>
       <li>Bugzilla: <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1964491" target="_blank" rel="noopener noreferrer">Issue tracking this behavior</a></li>
     </ul>
+    <p>
+      Once you allow it, you can select <b>"Disable initial hide action"</b> in extension settings to skip this startup initialization step in the future.
+    </p>
 
     <p>
       <b>Note #2:</b> "Disable initial hide action" only affects the startup permission initialization step. It does <b>not</b> change how matching/filtering works during a search session.

--- a/privacy.html
+++ b/privacy.html
@@ -12,6 +12,7 @@
       <li>This extension uses the <code>tabs.hide()</code> API to hide tabs.</li>
       <li>Firefox requires explicit user permission for this feature.</li>
     </ul>
+
     <p><b>On first use of the addon</b></p>
     <ul class="section-list">
       <li>Per Mozilla: "The first time an extension hides a tab, the browser will tell the user that the tab is being hidden, show them how they can access the hidden tab, and give them the option of disabling the extension instead."</li>
@@ -19,23 +20,32 @@
       <li>This action triggers Firefox to display a <b>privacy dialog</b> asking you to allow or deny tab hiding with this extension.</li>
       <li>This is only a workaround until the bug referenced in <b>Note #1</b> is fixed.</li>
     </ul>
+
     <p><b>What should you do?</b></p>
     <ul class="section-list">
       <li>To use tab hiding with this extension, click <b>Keep Tabs Hidden</b> in the dialog.</li>
       <li>To disable this feature, click <b>Disable Extension</b>.</li>
     </ul>
+
     <p>
-      <b>Note #1:</b> If you do not accept the permission, the dialog will appear each time the extension tries to hide a tab and will cause some UI conflicts between the search dialog and the Firefox privacy dialog. Once you allow it, you can select the <b>"Disable initial hide action"</b> option in the extension settings to prevent this initialization step in the future.
-      <ul class="section-list">
-        <li>Reference: <a href="https://discourse.mozilla.org/t/initial-tabs-hide-warning-dialog/142979" target="_blank" rel="noopener noreferrer">My discussion on Mozilla's Discourse site</a></li>
-        <li>Bugzilla: <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1964491" target="_blank" rel="noopener noreferrer">Issue tracking this behavior</a></li>
-      </ul>
+      <b>Note #1:</b> If you do not accept the permission, the dialog can appear each time the extension tries to hide a tab and may cause UI conflicts between the search dialog and Firefox's privacy dialog.
     </p>
     <p>
-      <b>Note #2:</b> This addon only uses hidden tabs when you are searching for tabs. Once you cancel the search (Pressing ESC key or clicking off of the dialog) or select the tab you want, all tabs are shown again with no tabs permanently hidden. Hidden tabs are only a temporary state while searching and should not affect your browsing experience.
+      Once you allow it, you can select <b>"Disable initial hide action"</b> in extension settings to skip this startup initialization step in the future.
+    </p>
+    <ul class="section-list">
+      <li>Reference: <a href="https://discourse.mozilla.org/t/initial-tabs-hide-warning-dialog/142979" target="_blank" rel="noopener noreferrer">My discussion on Mozilla's Discourse site</a></li>
+      <li>Bugzilla: <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1964491" target="_blank" rel="noopener noreferrer">Issue tracking this behavior</a></li>
+    </ul>
+
+    <p>
+      <b>Note #2:</b> "Disable initial hide action" only affects the startup permission initialization step. It does <b>not</b> change how matching/filtering works during a search session.
     </p>
     <p>
-      <b>Note #3:</b> This addon does not currently track or detect if another extension is already hiding tabs using <code>tabs.hide()</code>. If you use multiple tab-hiding extensions at the same time, this may cause conflicts or unexpected behavior. This is a limitation that may be addressed in a future update.
+      <b>Note #3:</b> This addon only uses hidden tabs while searching for tabs. Once you cancel the search (press ESC or click away from the dialog) or select the tab you want, all tabs are shown again. Hidden tabs are temporary and are not permanently hidden.
+    </p>
+    <p>
+      <b>Note #4:</b> This addon does not currently track or detect if another extension is already hiding tabs using <code>tabs.hide()</code>. If you use multiple tab-hiding extensions at the same time, this may cause conflicts or unexpected behavior.
     </p>
   </div>
   <div>

--- a/search-contents.html
+++ b/search-contents.html
@@ -7,26 +7,30 @@
 <body>
   <h1>Search Contents of Loaded Tabs</h1>
   <div class="info-box">
-    <p>
-      <strong>How it works:</strong>
-      <ul class="section-list">
-        <li>When you enable "Search contents of loaded tabs", the extension will search the visible text inside each open tab for your search term. Only tabs that contain the term will remain visible; others will be hidden.</li>
-      </ul>
-    </p>
-    <p>
-      <strong>Minimum Search Length:</strong>
-      <ul class="section-list">
-        <li>For performance and accuracy, content search requires a minimum of <b>3 characters</b> in your search term. If you enter fewer than 3 characters and only content search is enabled, no tabs will be hidden or filtered.</li>
-      </ul>
-    </p>
-    <p>
-      <strong>Notes:</strong>
-      <ul class="section-list">
-        <li>Content search only works on regular web pages (not special pages like about:blank or browser settings).</li>
-        <li>Tabs that are unloaded (discarded) cannot be searched until they are loaded.</li>
-        <li>The search is case-insensitive.</li>
-      </ul>
-    </p>
+    <strong>How it works:</strong>
+    <ul class="section-list">
+      <li>When you enable "Search contents of loaded tabs", the extension searches the visible text inside each open tab for your search term.</li>
+      <li>Tabs that contain the term remain visible; non-matching tabs are hidden.</li>
+    </ul>
+
+    <strong>Minimum Search Length:</strong>
+    <ul class="section-list">
+      <li>For performance and accuracy, content search requires a minimum of <b>3 characters</b> in your search term.</li>
+      <li>If you enter fewer than 3 characters and only content search is enabled, no tabs will be hidden or filtered.</li>
+    </ul>
+
+    <strong>Related Setting:</strong>
+    <ul class="section-list">
+      <li>"Disable initial hide action" only controls a startup permission initialization step.</li>
+      <li>It does <b>not</b> change how content search matches tabs or filters results during a search.</li>
+    </ul>
+
+    <strong>Notes:</strong>
+    <ul class="section-list">
+      <li>Content search only works on regular web pages (not special pages like about:blank or browser settings).</li>
+      <li>Tabs that are unloaded (discarded) cannot be searched until they are loaded.</li>
+      <li>The search is case-insensitive.</li>
+    </ul>
   </div>
   <p><button id="close-btn" class="close-btn">Close</button></p>
   <script src="search-contents.js"></script>


### PR DESCRIPTION
- Clarified option reset behavior in the popup.
    - Search-affecting options clear the active search and restore tabs to their pre-search state.
    - Both TST options ("Support for Tree Style Tab" and "Auto-expand trees with matched tabs") now reset an active search to ensure TST state is fully restored.
    - "Select all matching tabs on close" and "Disable initial hide action" do not reset an active search.
- Updated the TST search presentation.
    - Flattened search results now keep a consistent left and right gutter while searching.
    - Added defensive TST CSS so custom tab margins are less likely to break the flattened search layout.
- Updated the popup relationship between TST options.
    - The "Auto-expand trees with matched tabs" option is now progressively disclosed and only shown when TST support is enabled.
- Updated info-button behavior in the popup.
    - Opening privacy/content help now first resets any active search, then opens the help page in an active tab and closes the popup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded README with detailed popup and search-behavior semantics.
  * Updated help documentation for content search and permission initialization.
  * Revised privacy policy clarification on startup behavior and settings.

* **Style**
  * Refined UI layout and spacing for search-related options.

* **Chores**
  * Version bumped to v0.6.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->